### PR TITLE
Update default.nix

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
@@ -10,6 +10,6 @@ mkXfceDerivation rec {
   buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
 
   meta = {
-    description = "Internet load speed plugin for Xfce panel";
+    description = "Internet load speed plugin for Xfce4 panel";
   };
 }


### PR DESCRIPTION
- [n] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [y] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [y] Ensured that relevant documentation is up to date
- [y] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

xfce.xfce4-netload-plugin: change description from "Battery plugin for Xfce panel" to "Internet load plugin for Xfce4 panel"